### PR TITLE
Fix: Skip cutscenes

### DIFF
--- a/src/Dalamud.Plugin.SkipCutscene/Dalamud.Plugin.SkipCutscene.csproj
+++ b/src/Dalamud.Plugin.SkipCutscene/Dalamud.Plugin.SkipCutscene.csproj
@@ -1,14 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Dalamud.NET.Sdk/13.0.0">
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <Platforms>x64;AnyCPU</Platforms>
-    <Configurations>Debug;Pack</Configurations>
-  </PropertyGroup>
-  <Target Name="PackagePlugin" AfterTargets="Build" Condition="'$(Configuration)' == 'Pack'">
-    <DalamudPackager ProjectDir="$(ProjectDir)" OutputPath="$(OutputPath)" AssemblyName="$(AssemblyName)" VersionComponents="3" MakeZip="true" Exclude="$(AssemblyName).deps.json" />
-  </Target>
-  <ItemGroup>
-    <Content Include="Dalamud.Plugin.SkipCutscene.json" />
-  </ItemGroup>
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<Platforms>x64;AnyCPU</Platforms>
+		<Configurations>Debug;Pack</Configurations>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<Target Name="PackagePlugin" AfterTargets="Build" Condition="'$(Configuration)' == 'Pack'">
+		<DalamudPackager ProjectDir="$(ProjectDir)" OutputPath="$(OutputPath)" AssemblyName="$(AssemblyName)" VersionComponents="3" MakeZip="true" Exclude="$(AssemblyName).deps.json" />
+	</Target>
+	<ItemGroup>
+		<Reference Include="FFXIVClientStructs">
+			<HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\FFXIVClientStructs.dll</HintPath>
+		</Reference>
+	</ItemGroup>
+	<ItemGroup>
+		<Content Include="Dalamud.Plugin.SkipCutscene.json" />
+	</ItemGroup>
 </Project>

--- a/src/Dalamud.Plugin.SkipCutscene/GameData/Hooks.cs
+++ b/src/Dalamud.Plugin.SkipCutscene/GameData/Hooks.cs
@@ -1,0 +1,30 @@
+﻿using Dalamud.Hooking;
+using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using FFXIVClientStructs.FFXIV.Common.Lua;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dalamud.Plugin.SkipCutscene.GameData;
+public static class Hooks
+{
+    private const string CutsceneCreationSignature = "48 89 5C 24 ?? 57 48 83 EC ?? 48 8B D1 48 8D 4C 24 ?? E8 ?? ?? ?? ?? 48 8B 4C 24 ?? BA ?? ?? ?? ?? B3 ?? E8 ?? ?? ?? ?? BA ?? ?? ?? ?? 48 8D 4C 24 ?? 48 8B F8 E8 ?? ?? ?? ?? 48 8B 4C 24 ?? 4C 8B C0 BA ?? ?? ?? ?? E8 ?? ?? ?? ?? ?? ?? ?? 84 99";
+    // Todo, figure out what data is being pointed to.
+    public delegate bool CutsceneCreation(IntPtr pointer);
+    public static Hook<CutsceneCreation> CreateCutsceneCreationHook(
+        IGameInteropProvider interopProvider,
+        CutsceneCreation @delegate
+    ) =>
+        interopProvider.HookFromSignature(CutsceneCreationSignature, @delegate);
+
+    // Currently not used, may be helpful if we want to filter cutscenes.
+    public static Hook<UIState.Delegates.IsCutsceneSeen> CreateCutsceneHook(
+        IGameInteropProvider interopProvider,
+        UIState.Delegates.IsCutsceneSeen @delegate
+    ) =>
+        interopProvider.HookFromSignature(UIState.Addresses.IsCutsceneSeen.String, @delegate);
+
+}


### PR DESCRIPTION
Old signatures were still present, but nopping didn't seem to work anymore. This overwrites the entire hook which is a bit more rigorous but sets up better checking of contents.